### PR TITLE
use exec-bg for resilient background task execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +109,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -170,6 +191,7 @@ dependencies = [
  "chrono",
  "clap",
  "claude-codes",
+ "ctrlc",
  "serde",
  "serde_json",
  "toml",
@@ -186,6 +208,29 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "equivalent"
@@ -286,6 +331,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +350,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ toml = "0.8"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 claude-codes = { version = "2.1.53", default-features = false, features = ["types"] }
+ctrlc = "3"

--- a/SKILL.md
+++ b/SKILL.md
@@ -25,8 +25,8 @@ Do **not** use `claude9` for:
 
 - Running claude locally (just call `claude` directly).
 - General box management — it only does
-  `spawn` / `task` / `resume` / `talk` / `bash` / `config`.
-  No `ls`, `stop`, `rm`, `attach`. Use `run9` directly for those.
+  `spawn` / `task` / `resume` / `talk` / `bash` / `join` / `stop` / `ps` /
+  `config`. No `ls`, `rm`, `attach`. Use `run9` directly for those.
 
 ## Concepts
 
@@ -158,21 +158,31 @@ pre-forked detached snap instead.
 
 ### `claude9 task <box-id> [PROMPT...]`
 
-Run `claude -p --output-format stream-json --verbose "<prompt>"` on the box.
-Streams assistant text and tool-use markers live as they arrive. Saves the
-final `session_id` to `.claude9/state/<box-id>/session.txt`, overwriting any
-previous one. Exits non-zero if claude reports an error.
+Run `claude -p --output-format stream-json --verbose "<prompt>"` on the box
+as a **background exec** (`run9 box exec-bg`), then poll its output and
+stream it live. Because the task is detached on the remote side, a local
+network drop or Ctrl+C does not kill it — see **Background tasks** below
+for the detach/rejoin/stop flow. Saves the `session_id` to
+`.claude9/state/<box-id>/session.txt` as soon as claude reports it (not
+just on success), so `resume` still works even if the task is interrupted
+partway through.
+
+Only one background task per box at a time — if one is already running,
+`task` refuses and tells you to `join` or `stop` it first.
 
 ```sh
 claude9 task db9-a1b2c3d4 "audit the db9-server package for N+1 queries"
 claude9 task db9-a1b2c3d4 -f ./prompt.md
+# Ctrl+C → detach (task keeps running); claude9 join db9-a1b2c3d4 to reattach
 ```
 
 ### `claude9 resume <box-id> [PROMPT...]`
 
 Read the saved session id, then run
 `claude -p --resume <sid> --output-format stream-json --verbose "<prompt>"`.
-Same streaming display. Fails loudly if no session is saved for the box id.
+Runs as a background exec with the same detach / `join` / `stop`
+behavior as `claude9 task` — see **Background tasks**. Fails loudly if
+no session is saved for the box id.
 
 ```sh
 claude9 resume db9-a1b2c3d4 "now draft a fix for the worst three"
@@ -241,6 +251,65 @@ claude9 bash                               # interactive shell on base box
 claude9 bash db9-a1b2c3d4                  # interactive shell on a spawned box
 claude9 bash -- -lc 'ls /home/guy/workspace/repos'
 ```
+
+### `claude9 join <box-id>`
+
+Reattach to the background task currently running on a box. Replays the
+task's output from the beginning (via `run9 box exec-bg pull-output
+--from-start`), then keeps streaming new output until the task ends,
+Ctrl+C detaches again, or idle/hard deadline hits. Fails loudly if no
+background task is recorded for that box.
+
+```sh
+claude9 join db9-a1b2c3d4
+```
+
+### `claude9 stop <box-id>`
+
+Kill the background task on a box (`run9 box exec-bg kill`) and clear
+its local record. Use when the task is stuck or the prompt was wrong —
+regular completion clears the record automatically, so there's no need
+to call `stop` after a successful run.
+
+```sh
+claude9 stop db9-a1b2c3d4
+```
+
+### `claude9 ps`
+
+List background tasks known to this project group, one per line:
+`<box-id>  <age>  <prompt snippet>`. Only shows tasks in the current
+`.claude9/state/`, so unrelated project groups stay isolated.
+
+```sh
+claude9 ps
+```
+
+## Background tasks
+
+`claude9 task` runs claude under `run9 box exec-bg` so the task survives
+local disconnects. The model:
+
+- **Detach on Ctrl+C.** The remote claude keeps running; claude9 just
+  stops streaming and returns. Reattach with `claude9 join <box-id>`.
+- **Idle timeout: 1 h.** `run9 exec-bg` keeps a detached task alive as
+  long as something keeps pulling its output. Once nothing has pulled
+  for ~1 hour, the backend reaps it. Rule of thumb: if you walk away
+  for more than an hour, assume the task is gone.
+- **Hard deadline: 10 h.** Every task is launched with `--deadline=10h`,
+  which is the run9 ceiling. Anything still running at that point is
+  killed.
+- **One task per box.** `claude9 task` refuses to start a second task
+  while one is recorded; run a second task on a second box, or `stop`
+  the first.
+- **Remote is truth.** claude9 only remembers `exec_id` locally
+  (`.claude9/state/<box-id>/bg.toml`). Task status — running, done,
+  reaped — is always fetched from `run9 exec-bg pull-output`, never
+  guessed from a local flag.
+- **Session id is saved early.** As soon as claude emits its
+  `session_id` in the stream, it goes straight into `session.txt`. If
+  the task is interrupted before it finishes, `claude9 resume` can
+  still continue the conversation.
 
 ## Choosing a shape
 
@@ -346,7 +415,9 @@ Created by `claude9` in the project tree:
     └── <box-id>/
         ├── meta.toml      # box_id, base_box, snap_id, shape, created_at, projects[]
         ├── session.txt    # last claude session id (from task / resume)
-        └── history.jsonl  # append-only log of task / resume / talk invocations
+        ├── history.jsonl  # append-only log of task / resume / talk invocations
+        └── bg.toml        # current background task: exec_id, started_at, prompt_snippet
+                           # (only present while a task / resume is running; cleared on end)
 ```
 
 Hard-coded inside the remote box (contract with the base snap):
@@ -395,7 +466,7 @@ project groups stay isolated just by living in different directory trees.
 
 Not yet implemented, don't suggest these as if they work:
 
-- `claude9 ls` / `stop` / `rm` / `doctor`
+- `claude9 ls` / `rm` / `doctor`
 - Parallel repo sync
 - Remote-control / streaming of talk sessions (`talk` hands off to
   `run9 box exec -it` and doesn't intercept the stream)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,12 @@ pub enum Command {
     Talk(TalkArgs),
     /// Drop into `/bin/bash` on a run9 box (defaults to the configured base box)
     Bash(BashArgs),
+    /// Re-attach to a running background task on a box
+    Join(JoinArgs),
+    /// Stop a running background task on a box
+    Stop(StopArgs),
+    /// List background tasks
+    Ps,
 }
 
 #[derive(Args)]
@@ -128,4 +134,16 @@ pub struct ResumeArgs {
     /// Read follow-up from file instead of positional args
     #[arg(short, long)]
     pub file: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct JoinArgs {
+    /// Target box id
+    pub box_id: String,
+}
+
+#[derive(Args)]
+pub struct StopArgs {
+    /// Target box id
+    pub box_id: String,
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -448,6 +448,11 @@ impl ClaudeStreamState {
 
 const BG_DEADLINE: &str = "10h";
 const BG_POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// Max consecutive `pull-output` errors before we give up. Transient
+/// errors happen right after `exec-bg` returns (backend not yet ready)
+/// and sometimes once the exec is reaped after completion — both are
+/// expected and resolved on retry.
+const PULL_ERROR_LIMIT: u32 = 10;
 
 fn ensure_no_active_bg_task(box_id: &str) -> Result<()> {
     let existing = state::load_bg_task(box_id)?;
@@ -535,6 +540,7 @@ fn poll_bg_task(box_id: &str, exec_id: &str, from_start: bool) -> Result<()> {
     let mut line_buf = String::new();
     let mut session_saved = false;
     let mut first_pull = true;
+    let mut consecutive_errors: u32 = 0;
 
     let interrupted = Arc::new(AtomicBool::new(false));
     {
@@ -558,6 +564,7 @@ fn poll_bg_task(box_id: &str, exec_id: &str, from_start: bool) -> Result<()> {
 
         match run9::box_exec_bg_pull(exec_id, use_from_start) {
             Ok(chunk) => {
+                consecutive_errors = 0;
                 if !chunk.is_empty() {
                     line_buf.push_str(&chunk);
                     while let Some(pos) = line_buf.find('\n') {
@@ -568,8 +575,17 @@ fn poll_bg_task(box_id: &str, exec_id: &str, from_start: bool) -> Result<()> {
                 }
             }
             Err(e) => {
-                elog(format!("[claude9] task ended: {e}"));
-                break;
+                // Transient errors happen briefly right after exec-bg
+                // returns (backend not ready yet) and sometimes once the
+                // exec is cleaned up. Retry up to PULL_ERROR_LIMIT before
+                // giving up.
+                consecutive_errors += 1;
+                if stream.final_result.is_some() || consecutive_errors >= PULL_ERROR_LIMIT {
+                    if stream.final_result.is_none() {
+                        elog(format!("[claude9] task ended unexpectedly: {e}"));
+                    }
+                    break;
+                }
             }
         }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,14 +4,16 @@ use claude_codes::{ClaudeOutput, ContentBlock, ToolResultBlock, ToolResultConten
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::cli::{BashArgs, ResumeArgs, SpawnArgs, TalkArgs, TaskArgs};
+use crate::cli::{BashArgs, JoinArgs, ResumeArgs, SpawnArgs, StopArgs, TalkArgs, TaskArgs};
 use crate::config::{self, ClaudeOptions, REMOTE_USER, REPOS_DIR, WORKSPACE};
 use crate::resolver;
 use crate::run9;
-use crate::state::{self, BoxMeta};
+use crate::state::{self, BgTask, BoxMeta};
 
 /// Width of the `[HH:MM:SS] ` prefix that `elog` emits — used by
 /// `elog_cont` to left-pad continuation lines so they visually align
@@ -241,6 +243,47 @@ pub fn bash(args: BashArgs) -> Result<()> {
     Ok(())
 }
 
+pub fn join(args: JoinArgs) -> Result<()> {
+    let task = state::load_bg_task(&args.box_id)?
+        .ok_or_else(|| anyhow!("no background task on box {}", args.box_id))?;
+    elog(format!(
+        "[claude9] joining task on {} (exec_id={})",
+        args.box_id, task.exec_id
+    ));
+    poll_bg_task(&args.box_id, &task.exec_id, true)
+}
+
+pub fn stop(args: StopArgs) -> Result<()> {
+    let task = state::load_bg_task(&args.box_id)?
+        .ok_or_else(|| anyhow!("no background task on box {}", args.box_id))?;
+    elog(format!("[claude9] stopping task on {}", args.box_id));
+    match run9::box_exec_bg_kill(&task.exec_id) {
+        Ok(()) => elog("[claude9] stopped"),
+        Err(e) => elog(format!("[claude9] kill returned: {e}")),
+    }
+    state::clear_bg_task(&args.box_id)?;
+    Ok(())
+}
+
+pub fn ps() -> Result<()> {
+    let tasks = state::list_bg_tasks()?;
+    if tasks.is_empty() {
+        elog("[claude9] no background tasks");
+        return Ok(());
+    }
+    for (box_id, t) in &tasks {
+        let age = Utc::now().signed_duration_since(t.started_at);
+        let age_str = if age.num_hours() > 0 {
+            format!("{}h{}m ago", age.num_hours(), age.num_minutes() % 60)
+        } else {
+            format!("{}m ago", age.num_minutes())
+        };
+        let snippet: String = t.prompt_snippet.chars().take(60).collect();
+        eprintln!("  {box_id}  {age_str:>10}  {snippet}");
+    }
+    Ok(())
+}
+
 pub fn talk(args: TalkArgs) -> Result<()> {
     let mut cfg = config::load()?;
     // Per-invocation CLI overrides for model / effort, same pattern as
@@ -403,24 +446,42 @@ impl ClaudeStreamState {
     }
 }
 
+const BG_DEADLINE: &str = "10h";
+const BG_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+fn ensure_no_active_bg_task(box_id: &str) -> Result<()> {
+    let existing = state::load_bg_task(box_id)?;
+    let task = match existing {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+    // Probe whether the remote task is still alive.
+    match run9::box_exec_bg_pull(&task.exec_id, false) {
+        Ok(_) => {
+            bail!(
+                "box {box_id} already has a running task (exec_id={}). \
+                 Stop it first: claude9 stop {box_id}",
+                task.exec_id
+            );
+        }
+        Err(_) => {
+            state::clear_bg_task(box_id)?;
+            Ok(())
+        }
+    }
+}
+
 fn run_claude_task(
     box_id: &str,
     prompt: &str,
     resume_session: Option<&str>,
     claude_opts: &ClaudeOptions,
 ) -> Result<()> {
+    ensure_no_active_bg_task(box_id)?;
+
     let mut env = HashMap::new();
     env.insert("C9_PROMPT".into(), prompt.to_string());
 
-    // stream-json requires --verbose when used with --print/-p.
-    // Default resume behavior reuses the same session_id; pass --fork-session
-    // if you ever want a fresh id per turn.
-    //
-    // Extra flags (permission mode, tool allow/deny-lists) come from the
-    // `[claude]` section of config.toml. Headless mode can't show approval
-    // prompts, so tools like WebFetch are silently denied unless the user
-    // opts in via `permission_mode = "bypassPermissions"` or an explicit
-    // `allowed_tools` list.
     let extra_flags = build_claude_flags(claude_opts);
     let resume_frag = resume_session
         .map(|sid| format!(" --resume {}", shell_single_quote(sid)))
@@ -430,42 +491,126 @@ fn run_claude_task(
         r#"claude -p{resume_frag}{extra_flags} --output-format stream-json --verbose "$C9_PROMPT""#,
     );
 
-    elog(format!("[claude9] running claude -p on {box_id} (stream)"));
+    elog(format!("[claude9] launching background task on {box_id}"));
 
-    let mut stream = ClaudeStreamState::new();
-    run9::box_exec_streaming(
+    let created = run9::box_exec_bg(
         box_id,
         REMOTE_USER,
         WORKSPACE,
+        BG_DEADLINE,
         &env,
         &["/bin/bash", "-lc", &cmd],
-        |line| stream.handle_line(line),
     )?;
 
-    // Persist session id regardless of success, so a partially-failed turn
-    // can still be resumed.
-    if let Some(sid) = &stream.session_id {
-        state::save_session(box_id, sid)?;
-        elog(format!("[claude9] session: {sid}"));
+    let exec_id = created
+        .get("exec_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("exec-bg response missing exec_id: {created}"))?
+        .to_string();
+
+    elog(format!("[claude9] exec_id={exec_id}"));
+
+    let snippet: String = prompt.chars().take(200).collect();
+    let bg = BgTask {
+        exec_id: exec_id.clone(),
+        started_at: Utc::now(),
+        prompt_snippet: snippet,
+    };
+    state::save_bg_task(box_id, &bg)?;
+
+    let kind = if resume_session.is_some() {
+        "resume"
+    } else {
+        "task"
+    };
+    if let Err(e) = state::append_history(box_id, kind, prompt, None) {
+        elog(format!("[claude9] warn: history write failed: {e}"));
     }
+
+    poll_bg_task(box_id, &exec_id, false)
+}
+
+fn poll_bg_task(box_id: &str, exec_id: &str, from_start: bool) -> Result<()> {
+    let mut stream = ClaudeStreamState::new();
+    let mut line_buf = String::new();
+    let mut session_saved = false;
+    let mut first_pull = true;
+
+    let interrupted = Arc::new(AtomicBool::new(false));
+    {
+        let flag = interrupted.clone();
+        ctrlc::set_handler(move || {
+            flag.store(true, Ordering::SeqCst);
+        })
+        .ok();
+    }
+
+    loop {
+        if interrupted.load(Ordering::SeqCst) {
+            elog(format!(
+                "[claude9] detached — task keeps running. Rejoin: claude9 join {box_id}"
+            ));
+            return Ok(());
+        }
+
+        let use_from_start = from_start && first_pull;
+        first_pull = false;
+
+        match run9::box_exec_bg_pull(exec_id, use_from_start) {
+            Ok(chunk) => {
+                if !chunk.is_empty() {
+                    line_buf.push_str(&chunk);
+                    while let Some(pos) = line_buf.find('\n') {
+                        let line = line_buf[..pos].to_string();
+                        line_buf = line_buf[pos + 1..].to_string();
+                        stream.handle_line(&line);
+                    }
+                }
+            }
+            Err(e) => {
+                elog(format!("[claude9] task ended: {e}"));
+                break;
+            }
+        }
+
+        if !session_saved {
+            if let Some(sid) = &stream.session_id {
+                if let Err(e) = state::save_session(box_id, sid) {
+                    elog(format!("[claude9] warn: session write failed: {e}"));
+                } else {
+                    elog(format!("[claude9] session: {sid}"));
+                }
+                session_saved = true;
+            }
+        }
+
+        if stream.final_result.is_some() {
+            break;
+        }
+
+        thread::sleep(BG_POLL_INTERVAL);
+    }
+
+    // Flush any remaining partial line.
+    let tail = line_buf.trim();
+    if !tail.is_empty() {
+        stream.handle_line(tail);
+    }
+
+    if !session_saved {
+        if let Some(sid) = &stream.session_id {
+            let _ = state::save_session(box_id, sid);
+            elog(format!("[claude9] session: {sid}"));
+        }
+    }
+
+    state::clear_bg_task(box_id)?;
 
     if stream.is_error {
         bail!(
             "claude -p reported error: {}",
             stream.final_result.as_deref().unwrap_or("<no result>")
         );
-    }
-
-    // Record the invocation so the interactive picker can show recent
-    // activity on a box. Best-effort — a history write failure shouldn't
-    // flip an otherwise-successful task to a non-zero exit.
-    let kind = if resume_session.is_some() {
-        "resume"
-    } else {
-        "task"
-    };
-    if let Err(e) = state::append_history(box_id, kind, prompt, stream.session_id.as_deref()) {
-        elog(format!("[claude9] warn: history write failed: {e}"));
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,5 +17,8 @@ fn main() -> Result<()> {
         cli::Command::Resume(args) => commands::resume(args),
         cli::Command::Talk(args) => commands::talk(args),
         cli::Command::Bash(args) => commands::bash(args),
+        cli::Command::Join(args) => commands::join(args),
+        cli::Command::Stop(args) => commands::stop(args),
+        cli::Command::Ps => commands::ps(),
     }
 }

--- a/src/run9.rs
+++ b/src/run9.rs
@@ -1,9 +1,7 @@
 use anyhow::{bail, Context, Result};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader, Read};
 use std::process::{Command, ExitStatus, Stdio};
-use std::thread;
 
 fn run_raw(args: &[String]) -> Result<(String, String)> {
     let out = Command::new("run9")
@@ -106,68 +104,57 @@ pub fn box_exec(
     Ok(ExecResult { stdout, stderr })
 }
 
-/// Run a command inside a box via `run9 box exec`, streaming stdout
-/// line-by-line to a caller-supplied callback. stderr is drained in a
-/// background thread and returned as a single string on completion.
-///
-/// Used for `claude -p --output-format stream-json`: each JSON-lines event
-/// is handed to the callback as it arrives so the user sees live progress.
-pub fn box_exec_streaming<F>(
+pub fn box_exec_bg(
     box_id: &str,
     user: &str,
     workdir: &str,
+    deadline: &str,
     env: &HashMap<String, String>,
     command: &[&str],
-    mut on_stdout_line: F,
-) -> Result<ExecResult>
-where
-    F: FnMut(&str),
-{
-    let args = build_exec_args(box_id, user, workdir, env, command);
-
-    let mut child = Command::new("run9")
-        .args(&args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("failed to spawn run9; is it on PATH?")?;
-
-    let stdout_pipe = child.stdout.take().expect("stdout is piped");
-    let stderr_pipe = child.stderr.take().expect("stderr is piped");
-
-    // Drain stderr concurrently so a noisy stderr can't block stdout reads.
-    let stderr_handle = thread::spawn(move || -> String {
-        let mut buf = String::new();
-        let _ = BufReader::new(stderr_pipe).read_to_string(&mut buf);
-        buf
-    });
-
-    let mut stdout_buf = String::new();
-    let reader = BufReader::new(stdout_pipe);
-    for line in reader.lines() {
-        let line = line.context("reading run9 stdout")?;
-        on_stdout_line(&line);
-        stdout_buf.push_str(&line);
-        stdout_buf.push('\n');
+) -> Result<Value> {
+    let mut args: Vec<String> = vec![
+        "box".into(),
+        "exec-bg".into(),
+        box_id.into(),
+        format!("--deadline={deadline}"),
+        "--user".into(),
+        user.into(),
+        "--workdir".into(),
+        workdir.into(),
+    ];
+    for (k, v) in env {
+        args.push("-e".into());
+        args.push(format!("{k}={v}"));
     }
-
-    let status = child.wait().context("waiting for run9")?;
-    let stderr = stderr_handle.join().unwrap_or_default();
-
-    if !status.success() {
-        bail!(
-            "run9 {:?} failed (exit {}):\n{}",
-            args,
-            status.code().unwrap_or(-1),
-            stderr.trim_end()
-        );
+    args.push("--".into());
+    for c in command {
+        args.push((*c).into());
     }
+    run_json(&args)
+}
 
-    Ok(ExecResult {
-        stdout: stdout_buf,
-        stderr,
-    })
+pub fn box_exec_bg_pull(exec_id: &str, from_start: bool) -> Result<String> {
+    let mut args: Vec<String> = vec![
+        "box".into(),
+        "exec-bg".into(),
+        "pull-output".into(),
+        exec_id.into(),
+    ];
+    if from_start {
+        args.push("--from-start".into());
+    }
+    let (stdout, _) = run_raw(&args)?;
+    Ok(stdout)
+}
+
+pub fn box_exec_bg_kill(exec_id: &str) -> Result<()> {
+    run_raw(&[
+        "box".into(),
+        "exec-bg".into(),
+        "kill".into(),
+        exec_id.into(),
+    ])?;
+    Ok(())
 }
 
 /// Run a command inside a box via `run9 box exec -it`, letting the child

--- a/src/state.rs
+++ b/src/state.rs
@@ -119,6 +119,68 @@ pub fn load_history(box_id: &str) -> Result<Vec<HistoryEntry>> {
     Ok(entries)
 }
 
+// ── Background task bookkeeping ──────────────────────────────────────
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BgTask {
+    pub exec_id: String,
+    pub started_at: DateTime<Utc>,
+    pub prompt_snippet: String,
+}
+
+pub fn save_bg_task(box_id: &str, task: &BgTask) -> Result<()> {
+    let path = box_dir(box_id)?.join("bg.toml");
+    std::fs::write(&path, toml::to_string_pretty(task)?)?;
+    Ok(())
+}
+
+pub fn load_bg_task(box_id: &str) -> Result<Option<BgTask>> {
+    let path = box_dir(box_id)?.join("bg.toml");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let task: BgTask =
+        toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(Some(task))
+}
+
+pub fn clear_bg_task(box_id: &str) -> Result<()> {
+    let path = box_dir(box_id)?.join("bg.toml");
+    if path.exists() {
+        std::fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+pub fn list_bg_tasks() -> Result<Vec<(String, BgTask)>> {
+    let root = state_root()?;
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut results = Vec::new();
+    for entry in std::fs::read_dir(&root).with_context(|| format!("reading {}", root.display()))? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let bg_path = entry.path().join("bg.toml");
+        if !bg_path.exists() {
+            continue;
+        }
+        if let Ok(text) = std::fs::read_to_string(&bg_path) {
+            if let Ok(task) = toml::from_str::<BgTask>(&text) {
+                if let Some(name) = entry.file_name().to_str() {
+                    results.push((name.to_string(), task));
+                }
+            }
+        }
+    }
+    results.sort_by(|a, b| b.1.started_at.cmp(&a.1.started_at));
+    Ok(results)
+}
+
 /// Every box id under `.claude9/state/` whose directory name starts with
 /// `<prefix>-`. Does not validate the prefix format; caller is expected
 /// to have passed a user-supplied prefix string already.


### PR DESCRIPTION
## Summary

- Replace `run9 box exec` (streaming) with `run9 box exec-bg` for all `claude -p` task execution. Remote process survives client disconnects (network drop, Ctrl+C, laptop lid close).
- Add `claude9 join <box_id>` to re-attach and replay output from a running task.
- Add `claude9 stop <box_id>` to kill a background task.
- Add `claude9 ps` to list boxes with active tasks.
- Save `session_id` immediately on discovery (fixes resume after interruption).
- Line buffer across poll chunks prevents partial JSON line loss.
- One background task per box enforced with probe-before-start.

## Design decisions

- **No local output cache**: remote is the single source of truth. `join` uses `--from-start` to replay all output.
- **No status tracking in bg.toml**: only immutable facts (exec_id, started_at, prompt_snippet). Runtime state is always checked against the remote.
- **exec_id is internal**: users only interact via `box_id` they already know.
- **`talk` and `bash` unchanged**: interactive TTY sessions stay on `exec -it`.

## Constraints

- `--deadline=10h` (run9 hard limit)
- Each `pull-output` extends idle timeout by 1h — detaching for >1h risks idle timeout

## Test plan

- [ ] `claude9 task <box> "prompt"` — verify output streams via poll loop
- [ ] Ctrl+C during task — verify "detached" message, remote keeps running
- [ ] `claude9 join <box>` — verify output replays from start, then continues
- [ ] `claude9 stop <box>` — verify task is killed
- [ ] `claude9 ps` — verify listing shows box_id, age, prompt snippet
- [ ] `claude9 task` on box with existing task — verify rejection message
- [ ] `claude9 resume` — verify session_id was saved early, resume works
- [ ] `cargo test` — all 30 tests pass
- [ ] `cargo clippy` / `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)